### PR TITLE
Composer good practices

### DIFF
--- a/devops/deploy.yml
+++ b/devops/deploy.yml
@@ -29,7 +29,7 @@
         - templates/symfony/parameters.yml
 
     - name: update composer packages
-      action: command /usr/bin/composer update chdir=${webapps_dir}/${app_name}/src
+      action: command /usr/bin/composer install --no-dev -qn chdir=${webapps_dir}/${app_name}/src
 
     - name: install nginx fastcgi_param
       action: template src=templates/nginx/fastcgi_param dest=/etc/nginx/fastcgi_param


### PR DESCRIPTION
In production environments, you should use install over update (you must commit composer.lock file anytime you change something in it from development that you want to apply in prod)

--no-dev will not install phpunit or other packages only needed in development environments (you define them as so in composer.json)
also, -q no output and -n no interaction
